### PR TITLE
adding fix for person-card images

### DIFF
--- a/assets/css/modules/_persons.styl
+++ b/assets/css/modules/_persons.styl
@@ -459,6 +459,7 @@
 }
 
 .fs-person-portrait__image {
+  max-width: 100%;
   border-radius: 50%;
   position: relative;
   z-index: 1;


### PR DESCRIPTION
For the tree, bootstrap was giving us this max width, but we need to supply it ourselves instead of relying on bootstrap.