### PR TITLE
Adding full styles web component.

### DIFF
--- a/fs-styles-full.html
+++ b/fs-styles-full.html
@@ -1,0 +1,3 @@
+<dom-module id="fs-styles">
+  <link rel="import" type="css" href="dist/familysearch-styles.min.css">
+</dom-module>


### PR DESCRIPTION
### Update
-On occasion, our team has the need to consume the entire `fs-styles` styleguide as a web component. The current `fs-styles` component only references the `base.min.css` file. There are some rare cases when we need the entire `familysearch-styles.min.css` file.
@straker / @jpodwys 