### PR TITLE
Adjusted fs-line-height-large-xx to 2.22 rem

### DIFF
--- a/assets/css/helpers/_variables.styl
+++ b/assets/css/helpers/_variables.styl
@@ -757,7 +757,7 @@ $line-height-small = 1.35rem;
 $line-height-medium = unit($baseline-grid, 'rem');
 $line-height-large = unit($baseline-grid, 'rem');
 $line-height-large-x = 1.95rem;
-$line-height-large-xx = 2.15rem;
+$line-height-large-xx = 2.22rem;
 $line-height-large-xxx = 2.5rem;
 $line-height-large-xxxx = 2.875rem;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-styles",
   "description": "Global styles for the FamilySearch.org website.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "keywords": [
     "css",
     "stylus",


### PR DESCRIPTION
[JIRA](https://almtools.ldschurch.org/fhjira/browse/TW-1274?filter=38754)

There are two PRs for this issue. [Here is the other one](https://github.com/fs-webdev/fs-person/pull/21).

On the person page, when the focused person's name uses diacritics that go above the character, it is clipped since its styling uses `overflow: hidden` to allow `text-overflow: ellipsis` to work.

This pull requests adjusts the `fs-line-height-large-xx` variable to `2.22rem` from `2.15rem` to allow enough space for diacritics. The other pull request adjusts the icon next to the person's name to meet the adjusted line-height.